### PR TITLE
Development and repair

### DIFF
--- a/api/mraa/types.h
+++ b/api/mraa/types.h
@@ -69,6 +69,9 @@ typedef enum {
     MRAA_UPXTREME = 24,             /**< The UPXTREME Board */
     MRAA_ROCKPIS = 25,              /**< Radxa ROCK PI S Board */
     MRAA_ROCKPIN10 = 26,              /**< Radxa ROCK PI N 10 Board */
+    MRAA_ROCKPIE = 27,              /**< Radxa ROCK PI E V1.2 */
+    MRAA_ROCKPIE_V11 = 28,          /**< Radxa ROCK PI E V1.1 */
+    MRAA_ROCKPIX = 29,              /**< Radxa ROCK PI X V1.4 */
     // USB platform extenders start at 256
     MRAA_FTDI_FT4222 = 256,         /**< FTDI FT4222 USB to i2c bridge */
 

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,6 +1,12 @@
 add_subdirectory (c)
 add_subdirectory (platform)
 
+if ( (DEFINED ENV{JAVA_HOME_NATIVE}) OR (DEFINED ENV{JAVA_HOME}) )
+  #add_subdirectory (java)
+else ()
+  #message ( WARNING "You haven't configured the Java environment variables yet!")
+endif ()
+
 if (NOT ANDROID_TOOLCHAIN)
   add_subdirectory (c++)
 endif ()

--- a/examples/java/CMakeLists.txt
+++ b/examples/java/CMakeLists.txt
@@ -1,0 +1,36 @@
+if (NOT DEFINED ENV{JAVA_HOME_NATIVE})
+    if (NOT DEFINED ENV{JAVA_HOME})
+        message (FATAL_ERROR "Neither JAVA_HOME nor JAVA_HOME_NATIVE are set")
+    endif()
+    set (JAVA_HOME_NATIVE $ENV{JAVA_HOME})
+    set (JAVAC $ENV{JAVA_HOME}/bin/javac)
+    set (JAR $ENV{JAVA_HOME}/bin/jar)
+else ()
+    set (JAVAC $ENV{JAVA_HOME_NATIVE}/bin/javac)
+    set (JAR $ENV{JAVA_HOME_NATIVE}/bin/jar)
+endif ()
+
+set (Main_Class_Name_list
+        AioA0 BlinkIO BlinkOnboard Bmp85
+        CyclePwm3 Example FTDITest GpioMmapped
+        GpioRead6 HelloEdison I2cCompass Isr
+        SpiMAX7219 SpiMCP4261 UartExample)
+
+foreach (Main_Class_Name ${Main_Class_Name_list})
+    configure_file (
+        ${CMAKE_CURRENT_SOURCE_DIR}/manifest.txt.in
+        ${CMAKE_CURRENT_BINARY_DIR}/${Main_Class_Name}/manifest.txt
+        @ONLY
+    )
+
+    if (EXISTS "${CMAKE_CURRENT_BINARY_DIR}/../../src/java/mraa.jar")
+        set (mraa_jar_path ${CMAKE_CURRENT_BINARY_DIR}/../../src/java/mraa.jar)
+    elseif (EXISTS "/usr/local/lib/java/mraa.jar")
+        set (mraa_jar_path /usr/local/lib/java/mraa.jar)
+    endif()
+
+    add_custom_target (${Main_Class_Name}_jar ALL
+        COMMAND ${JAVAC} -cp ${mraa_jar_path} -d ${CMAKE_CURRENT_BINARY_DIR}/${Main_Class_Name} ${CMAKE_CURRENT_SOURCE_DIR}/${Main_Class_Name}.java
+        COMMAND cd ${CMAKE_CURRENT_BINARY_DIR}/${Main_Class_Name}/ && ${JAR} -cmvf manifest.txt ${Main_Class_Name}.jar ${Main_Class_Name}.class
+    )
+endforeach ()

--- a/include/arm/rockpie.h
+++ b/include/arm/rockpie.h
@@ -1,0 +1,29 @@
+/*
+ * Author: Brian <brian@vamrs.com>
+ * Copyright (c) 2019 Vamrs Corporation.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#pragma once
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "mraa_internal.h"
+
+#define MRAA_ROCKPIE_GPIO_COUNT 25
+#define MRAA_ROCKPIE_I2C_COUNT  1
+#define MRAA_ROCKPIE_SPI_COUNT  1
+#define MRAA_ROCKPIE_UART_COUNT 2
+#define MRAA_ROCKPIE_PWM_COUNT  1
+#define MRAA_ROCKPIE_AIO_COUNT  1
+#define MRAA_ROCKPIE_PIN_COUNT  40
+
+mraa_board_t *
+        mraa_rockpie();
+
+#ifdef __cplusplus
+}
+#endif

--- a/include/arm/rockpie_v11.h
+++ b/include/arm/rockpie_v11.h
@@ -1,0 +1,29 @@
+/*
+ * Author: Brian <brian@vamrs.com>
+ * Copyright (c) 2019 Vamrs Corporation.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#pragma once
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "mraa_internal.h"
+
+#define MRAA_ROCKPIE_V11_GPIO_COUNT 27
+#define MRAA_ROCKPIE_V11_I2C_COUNT  1
+#define MRAA_ROCKPIE_V11_SPI_COUNT  1
+#define MRAA_ROCKPIE_V11_UART_COUNT 2
+#define MRAA_ROCKPIE_V11_PWM_COUNT  0
+#define MRAA_ROCKPIE_V11_AIO_COUNT  1
+#define MRAA_ROCKPIE_V11_PIN_COUNT  40
+
+mraa_board_t *
+        mraa_rockpie_v11();
+
+#ifdef __cplusplus
+}
+#endif

--- a/include/x86/rockpix.h
+++ b/include/x86/rockpix.h
@@ -1,0 +1,29 @@
+/*
+ * Author: Shine <yll@radxa.com>
+ * Copyright (c) 2020 Vamrs Corporation.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#pragma once
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "mraa_internal.h"
+
+// +1 as pins are "1 indexed"
+#define MRAA_ROCKPIX_PINCOUNT (40 + 1)
+#define MRAA_ROCKPIX_GPIOCOUNT (10)
+#define MRAA_ROCKPIX_PWM_COUNT 2
+#define MRAA_ROCKPIX_SPI_COUNT 1
+#define MRAA_ROCKPIX_UART_COUNT 1
+#define MRAA_ROCKPIX_ADC_COUNT 0
+
+mraa_board_t*
+mraa_rockpix_board();
+
+#ifdef __cplusplus
+}
+#endif

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -57,6 +57,7 @@ set (mraa_LIB_X86_SRCS_NOAUTO
   ${PROJECT_SOURCE_DIR}/src/x86/iei_tank.c
   ${PROJECT_SOURCE_DIR}/src/x86/adlink-ipi.c
   ${PROJECT_SOURCE_DIR}/src/x86/up_xtreme.c
+  ${PROJECT_SOURCE_DIR}/src/x86/rockpix.c
 )
 
 message (STATUS "INFO - Adding support for platform ${MRAAPLATFORMFORCE}")
@@ -108,6 +109,8 @@ set (mraa_LIB_ARM_SRCS_NOAUTO
   ${PROJECT_SOURCE_DIR}/src/arm/rockpi4.c
   ${PROJECT_SOURCE_DIR}/src/arm/rockpis.c
   ${PROJECT_SOURCE_DIR}/src/arm/rockpin10.c
+  ${PROJECT_SOURCE_DIR}/src/arm/rockpie.c
+  ${PROJECT_SOURCE_DIR}/src/arm/rockpie_v11.c
   ${PROJECT_SOURCE_DIR}/src/arm/adlink_ipi.c
 )
 

--- a/src/arm/arm.c
+++ b/src/arm/arm.c
@@ -13,6 +13,8 @@
 #include "arm/rockpi4.h"
 #include "arm/rockpis.h"
 #include "arm/rockpin10.h"
+#include "arm/rockpie.h"
+#include "arm/rockpie_v11.h"
 #include "arm/de_nano_soc.h"
 #include "arm/banana.h"
 #include "arm/beaglebone.h"
@@ -94,13 +96,18 @@ mraa_arm_platform()
             platform_type = MRAA_96BOARDS;
         else if (mraa_file_contains("/proc/device-tree/model", "ROCK Pi 4")  ||
                  mraa_file_contains("/proc/device-tree/model", "ROCK PI 4A") ||
-                 mraa_file_contains("/proc/device-tree/model", "ROCK PI 4B")
+                 mraa_file_contains("/proc/device-tree/model", "ROCK PI 4B") ||
+                 mraa_file_contains("/proc/device-tree/model", "ROCK PI 4C")
                  )
             platform_type = MRAA_ROCKPI4;
         else if (mraa_file_contains("/proc/device-tree/model", "Radxa ROCK Pi S"))
             platform_type = MRAA_ROCKPIS;
         else if (mraa_file_contains("/proc/device-tree/model", "Radxa ROCK Pi N10"))
             platform_type = MRAA_ROCKPIN10;
+        else if (mraa_file_contains("/proc/device-tree/model", "ROCK Pi E V11"))
+            platform_type = MRAA_ROCKPIE_V11;
+        else if (mraa_file_contains("/proc/device-tree/model", "ROCK Pi E"))
+            platform_type = MRAA_ROCKPIE;
         else if (mraa_file_contains("/proc/device-tree/compatible", "raspberrypi,"))
             platform_type = MRAA_RASPBERRY_PI;
         else if (mraa_file_contains("/proc/device-tree/model", "ADLINK ARM, LEC-PX30"))
@@ -131,6 +138,12 @@ mraa_arm_platform()
             break;
         case MRAA_ROCKPIN10:
             plat = mraa_rockpin10();
+            break;
+        case MRAA_ROCKPIE:
+            plat = mraa_rockpie();
+            break;
+        case MRAA_ROCKPIE_V11:
+            plat = mraa_rockpie_v11();
             break;
         case MRAA_DE_NANO_SOC:
             plat = mraa_de_nano_soc();

--- a/src/arm/rockpi4.c
+++ b/src/arm/rockpi4.c
@@ -23,6 +23,7 @@
 #define PLATFORM_NAME_ROCK_PI_4 "ROCK Pi 4"
 #define PLATFORM_NAME_ROCK_PI_4A "ROCK PI 4A"
 #define PLATFORM_NAME_ROCK_PI_4B "ROCK PI 4B"
+#define PLATFORM_NAME_ROCK_PI_4C "ROCK PI 4C"
 #define MAX_SIZE 64
 
 const char* rockpi4_serialdev[MRAA_ROCKPI4_UART_COUNT] = { "/dev/ttyS2","/dev/ttyS4"};
@@ -69,13 +70,15 @@ mraa_rockpi4()
     b->no_bus_mux = 1;
     b->phy_pin_count = MRAA_ROCKPI4_PIN_COUNT + 1;
 
+    const char *Rockpi;
     if (mraa_file_exist(DT_BASE "/model")) {
         // We are on a modern kernel, great!!!!
-        if (mraa_file_contains(DT_BASE "/model", PLATFORM_NAME_ROCK_PI_4)  ||
-            mraa_file_contains(DT_BASE "/model", PLATFORM_NAME_ROCK_PI_4A) ||
-            mraa_file_contains(DT_BASE "/model", PLATFORM_NAME_ROCK_PI_4B)
+        if (mraa_file_contains(DT_BASE "/model", PLATFORM_NAME_ROCK_PI_4) ? Rockpi = PLATFORM_NAME_ROCK_PI_4 : 0 ||
+            mraa_file_contains(DT_BASE "/model", PLATFORM_NAME_ROCK_PI_4A) ? Rockpi = PLATFORM_NAME_ROCK_PI_4A : 0 ||
+            mraa_file_contains(DT_BASE "/model", PLATFORM_NAME_ROCK_PI_4B) ? Rockpi = PLATFORM_NAME_ROCK_PI_4B : 0 ||
+            mraa_file_contains(DT_BASE "/model", PLATFORM_NAME_ROCK_PI_4C) ? Rockpi = PLATFORM_NAME_ROCK_PI_4C : 0
             ) {
-            b->platform_name = PLATFORM_NAME_ROCK_PI_4;
+            b->platform_name = Rockpi;
             b->uart_dev[0].device_path = (char*) rockpi4_serialdev[0];
             b->uart_dev[1].device_path = (char*) rockpi4_serialdev[1];
         }

--- a/src/arm/rockpie.c
+++ b/src/arm/rockpie.c
@@ -1,0 +1,167 @@
+/*
+ * Author: Shine <Shine@radxa.com>
+ * Copyright (c) 2020 Vamrs Corporation.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include <mraa/common.h>
+#include <stdarg.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/mman.h>
+
+#include "arm/rockpie.h"
+#include "common.h"
+
+#define DT_BASE "/proc/device-tree"
+/*
+* "Radxa ROCK Pi 4" is the model name on stock 5.x kernels
+* "ROCK PI 4A", "ROCK PI 4B" is used on Radxa 4.4 kernel
+* so we search for the string below by ignoring case
+*/
+#define PLATFORM_NAME_ROCK_PI_E "ROCK Pi E"
+#define MAX_SIZE 64
+
+const char* rockpie_serialdev[MRAA_ROCKPIE_UART_COUNT] = { "/dev/ttyS1","/dev/ttyS2"};
+
+void
+mraa_rockpie_pininfo(mraa_board_t* board, int index, int sysfs_pin, mraa_pincapabilities_t pincapabilities_t, char* fmt, ...)
+{
+
+    va_list arg_ptr;
+
+    if (index > board->phy_pin_count)
+        return;
+
+    mraa_pininfo_t* pininfo = &board->pins[index];
+    va_start(arg_ptr, fmt);
+    vsnprintf(pininfo->name, MRAA_PIN_NAME_SIZE, fmt, arg_ptr);
+
+    if( pincapabilities_t.gpio == 1 ) {
+	va_arg(arg_ptr, int);
+	pininfo->gpio.gpio_chip = va_arg(arg_ptr, int);
+	pininfo->gpio.gpio_line = va_arg(arg_ptr, int);
+    }
+
+    pininfo->capabilities = pincapabilities_t;
+
+    va_end(arg_ptr);
+    pininfo->gpio.pinmap = sysfs_pin;
+    pininfo->gpio.mux_total = 0;
+}
+
+mraa_board_t*
+mraa_rockpie()
+{
+    mraa_board_t* b = (mraa_board_t*) calloc(1, sizeof(mraa_board_t));
+    if (b == NULL) {
+        return NULL;
+    }
+
+    b->adv_func = (mraa_adv_func_t*) calloc(1, sizeof(mraa_adv_func_t));
+    if (b->adv_func == NULL) {
+        free(b);
+        return NULL;
+    }
+
+    // pin mux for buses are setup by default by kernel so tell mraa to ignore them
+    b->no_bus_mux = 1;
+    b->phy_pin_count = MRAA_ROCKPIE_PIN_COUNT + 1;
+
+    if (mraa_file_exist(DT_BASE "/model")) {
+        // We are on a modern kernel, great!!!!
+        if (mraa_file_contains(DT_BASE "/model", PLATFORM_NAME_ROCK_PI_E)) {
+            b->platform_name = PLATFORM_NAME_ROCK_PI_E;
+            b->uart_dev[0].device_path = (char*) rockpie_serialdev[0];
+            b->uart_dev[1].device_path = (char*) rockpie_serialdev[1];
+        }
+    }
+
+    // UART
+    b->uart_dev_count = MRAA_ROCKPIE_UART_COUNT;
+    b->def_uart_dev = 0;
+    b->uart_dev[0].index = 1;
+    b->uart_dev[1].index = 2;
+
+    // I2C
+    if (strncmp(b->platform_name, PLATFORM_NAME_ROCK_PI_E, MAX_SIZE) == 0) {
+        b->i2c_bus_count = MRAA_ROCKPIE_I2C_COUNT;
+        b->def_i2c_bus = 0;
+        b->i2c_bus[0].bus_id = 1;
+    }
+
+    // SPI
+    b->spi_bus_count = MRAA_ROCKPIE_SPI_COUNT;
+    b->def_spi_bus = 0;
+    b->spi_bus[0].bus_id = 32766;
+
+    b->pins = (mraa_pininfo_t*) malloc(sizeof(mraa_pininfo_t) * b->phy_pin_count);
+    if (b->pins == NULL) {
+        free(b->adv_func);
+        free(b);
+        return NULL;
+    }
+
+    /* ADC */
+    b->aio_count = MRAA_ROCKPIE_AIO_COUNT;
+    b->adc_raw = 10;
+    b->adc_supported = 10;
+    b->aio_dev[0].pin = 22;
+    b->aio_non_seq = 1;
+    b->pins[22].aio.pinmap = 1;
+
+    /* PWM1,2 */
+    b->pwm_dev_count = MRAA_ROCKPIE_PWM_COUNT;
+    b->pwm_default_period = 500;
+    b->pwm_max_period = 2147483;
+    b->pwm_min_period = 1;
+
+    b->pins[33].pwm.parent_id = 2;
+    b->pins[33].pwm.mux_total = 0;
+    b->pins[33].pwm.pinmap = 0;
+
+    mraa_rockpie_pininfo(b, 0,   -1, (mraa_pincapabilities_t){0,0,0,0,0,0,0,0}, "INVALID");
+    mraa_rockpie_pininfo(b, 1,   -1, (mraa_pincapabilities_t){1,0,0,0,0,0,0,0}, "3V3");
+    mraa_rockpie_pininfo(b, 2,   -1, (mraa_pincapabilities_t){1,0,0,0,0,0,0,0}, "5V");
+    mraa_rockpie_pininfo(b, 3,  100, (mraa_pincapabilities_t){1,1,0,0,0,0,0,1}, "UART1_TX");
+    mraa_rockpie_pininfo(b, 4,   -1, (mraa_pincapabilities_t){1,0,0,0,0,0,0,0}, "5V");
+    mraa_rockpie_pininfo(b, 5,  102, (mraa_pincapabilities_t){1,1,0,0,0,0,0,1}, "UART1_RX");
+    mraa_rockpie_pininfo(b, 6,   -1, (mraa_pincapabilities_t){1,0,0,0,0,0,0,0}, "GND");
+    mraa_rockpie_pininfo(b, 7,   60, (mraa_pincapabilities_t){1,1,0,0,0,0,0,0}, "GPIO1_D4");
+    mraa_rockpie_pininfo(b, 8,   64, (mraa_pincapabilities_t){1,1,0,0,0,0,0,1}, "UART2_TX");
+    mraa_rockpie_pininfo(b, 9,   -1, (mraa_pincapabilities_t){1,0,0,0,0,0,0,0}, "GND");
+    mraa_rockpie_pininfo(b, 10,  65, (mraa_pincapabilities_t){1,1,0,0,0,0,0,1}, "UART2_RX");
+    mraa_rockpie_pininfo(b, 11,  66, (mraa_pincapabilities_t){1,1,1,0,0,0,0,0}, "PWM_IR");
+    mraa_rockpie_pininfo(b, 12,  82, (mraa_pincapabilities_t){1,1,0,0,0,0,0,0}, "GPIO2_C2");
+    mraa_rockpie_pininfo(b, 13,  67, (mraa_pincapabilities_t){1,1,0,0,0,0,0,0}, "GPIO2_A3");
+    mraa_rockpie_pininfo(b, 14,  -1, (mraa_pincapabilities_t){1,0,0,0,0,0,0,0}, "GND");
+    mraa_rockpie_pininfo(b, 15,  27, (mraa_pincapabilities_t){1,1,0,0,0,0,0,0}, "GPIO0_D3");
+    mraa_rockpie_pininfo(b, 16,  -1, (mraa_pincapabilities_t){1,0,0,0,0,0,0,0}, "USB20DM");
+    mraa_rockpie_pininfo(b, 17,  -1, (mraa_pincapabilities_t){1,0,0,0,0,0,0,0}, "3V3");
+    mraa_rockpie_pininfo(b, 18,  -1, (mraa_pincapabilities_t){1,0,0,0,0,0,0,0}, "USB20DP");
+    mraa_rockpie_pininfo(b, 19,  97, (mraa_pincapabilities_t){1,1,0,0,1,0,0,0}, "SPI0_TXD");
+    mraa_rockpie_pininfo(b, 20,  -1, (mraa_pincapabilities_t){1,0,0,0,0,0,0,0}, "GND");
+    mraa_rockpie_pininfo(b, 21,  98, (mraa_pincapabilities_t){1,1,0,0,1,0,0,0}, "SPI0_RXD");
+    mraa_rockpie_pininfo(b, 22,  76, (mraa_pincapabilities_t){1,1,0,0,0,0,1,0}, "ADC_IN1");
+    mraa_rockpie_pininfo(b, 23,  96, (mraa_pincapabilities_t){1,1,0,0,1,0,0,0}, "SPI0_CLK");
+    mraa_rockpie_pininfo(b, 24, 104, (mraa_pincapabilities_t){1,1,0,0,1,0,0,0}, "SPI0_CSN0");
+    mraa_rockpie_pininfo(b, 25,  -1, (mraa_pincapabilities_t){1,0,0,0,0,0,0,0}, "GND");
+    mraa_rockpie_pininfo(b, 26,  76, (mraa_pincapabilities_t){1,1,0,0,0,0,0,0}, "GPIO2_B4");
+    mraa_rockpie_pininfo(b, 27,  68, (mraa_pincapabilities_t){1,1,0,0,0,1,0,0}, "I2C1_SDA");
+    mraa_rockpie_pininfo(b, 28,  69, (mraa_pincapabilities_t){1,1,0,0,0,1,0,0}, "I2C1_SCL");
+    mraa_rockpie_pininfo(b, 29,  84, (mraa_pincapabilities_t){1,1,0,0,0,0,0,0}, "GPIO2_C4");
+    mraa_rockpie_pininfo(b, 30,  -1, (mraa_pincapabilities_t){1,0,0,0,0,0,0,0}, "GND");
+    mraa_rockpie_pininfo(b, 31,  85, (mraa_pincapabilities_t){1,1,0,0,0,0,0,0}, "GPIO2_C5");
+    mraa_rockpie_pininfo(b, 32,  80, (mraa_pincapabilities_t){1,1,0,0,0,0,0,0}, "GPIO2_C0");
+    mraa_rockpie_pininfo(b, 33,  70, (mraa_pincapabilities_t){1,1,0,0,0,0,0,0}, "PWM2");
+    mraa_rockpie_pininfo(b, 34,  -1, (mraa_pincapabilities_t){1,0,0,0,0,0,0,0}, "GND");
+    mraa_rockpie_pininfo(b, 35,  81, (mraa_pincapabilities_t){1,1,0,0,0,0,0,0}, "GPIO2_C1");
+    mraa_rockpie_pininfo(b, 36,  79, (mraa_pincapabilities_t){1,1,0,0,0,0,0,0}, "GPIO2_B7");
+    mraa_rockpie_pininfo(b, 37,  86, (mraa_pincapabilities_t){1,1,0,0,0,0,0,0}, "GPIO2_C6");
+    mraa_rockpie_pininfo(b, 38,  83, (mraa_pincapabilities_t){1,1,0,0,0,0,0,0}, "GPIO2_C3");
+    mraa_rockpie_pininfo(b, 39,  -1, (mraa_pincapabilities_t){1,0,0,0,0,0,0,0}, "GND");
+    mraa_rockpie_pininfo(b, 40,  87, (mraa_pincapabilities_t){1,1,0,0,0,0,0,0}, "GPIO2_C7");
+
+    return b;
+}

--- a/src/arm/rockpie_v11.c
+++ b/src/arm/rockpie_v11.c
@@ -1,0 +1,157 @@
+/*
+ * Author: Shine <Shine@radxa.com>
+ * Copyright (c) 2020 Vamrs Corporation.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include <mraa/common.h>
+#include <stdarg.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/mman.h>
+
+#include "arm/rockpie_v11.h"
+#include "common.h"
+
+#define DT_BASE "/proc/device-tree"
+/*
+* "Radxa ROCK Pi 4" is the model name on stock 5.x kernels
+* "ROCK PI 4A", "ROCK PI 4B" is used on Radxa 4.4 kernel
+* so we search for the string below by ignoring case
+*/
+#define PLATFORM_NAME_ROCK_PI_E_V11 "ROCK Pi E V11"
+#define MAX_SIZE 64
+
+const char* rockpie_v11_serialdev[MRAA_ROCKPIE_V11_UART_COUNT] = { "/dev/ttyS1","/dev/ttyS2"};
+
+void
+mraa_rockpie_v11_pininfo(mraa_board_t* board, int index, int sysfs_pin, mraa_pincapabilities_t pincapabilities_t, char* fmt, ...)
+{
+
+    va_list arg_ptr;
+
+    if (index > board->phy_pin_count)
+        return;
+
+    mraa_pininfo_t* pininfo = &board->pins[index];
+    va_start(arg_ptr, fmt);
+    vsnprintf(pininfo->name, MRAA_PIN_NAME_SIZE, fmt, arg_ptr);
+
+    if( pincapabilities_t.gpio == 1 ) {
+	va_arg(arg_ptr, int);
+	pininfo->gpio.gpio_chip = va_arg(arg_ptr, int);
+	pininfo->gpio.gpio_line = va_arg(arg_ptr, int);
+    }
+
+    pininfo->capabilities = pincapabilities_t;
+
+    va_end(arg_ptr);
+    pininfo->gpio.pinmap = sysfs_pin;
+    pininfo->gpio.mux_total = 0;
+}
+
+mraa_board_t*
+mraa_rockpie_v11()
+{
+    mraa_board_t* b = (mraa_board_t*) calloc(1, sizeof(mraa_board_t));
+    if (b == NULL) {
+        return NULL;
+    }
+
+    b->adv_func = (mraa_adv_func_t*) calloc(1, sizeof(mraa_adv_func_t));
+    if (b->adv_func == NULL) {
+        free(b);
+        return NULL;
+    }
+
+    // pin mux for buses are setup by default by kernel so tell mraa to ignore them
+    b->no_bus_mux = 1;
+    b->phy_pin_count = MRAA_ROCKPIE_V11_PIN_COUNT + 1;
+
+    if (mraa_file_exist(DT_BASE "/model")) {
+        // We are on a modern kernel, great!!!!
+        if (mraa_file_contains(DT_BASE "/model", PLATFORM_NAME_ROCK_PI_E_V11)) {
+            b->platform_name = PLATFORM_NAME_ROCK_PI_E_V11;
+            b->uart_dev[0].device_path = (char*) rockpie_v11_serialdev[0];
+            b->uart_dev[1].device_path = (char*) rockpie_v11_serialdev[1];
+        }
+    }
+
+    // UART
+    b->uart_dev_count = MRAA_ROCKPIE_V11_UART_COUNT;
+    b->def_uart_dev = 0;
+    b->uart_dev[0].index = 1;
+    b->uart_dev[1].index = 2;
+
+    // I2C
+    if (strncmp(b->platform_name, PLATFORM_NAME_ROCK_PI_E_V11, MAX_SIZE) == 0) {
+        b->i2c_bus_count = MRAA_ROCKPIE_V11_I2C_COUNT;
+        b->def_i2c_bus = 0;
+        b->i2c_bus[0].bus_id = 1;
+    }
+
+    // SPI
+    b->spi_bus_count = MRAA_ROCKPIE_V11_SPI_COUNT;
+    b->def_spi_bus = 0;
+    b->spi_bus[0].bus_id = 32766;
+
+    b->pins = (mraa_pininfo_t*) malloc(sizeof(mraa_pininfo_t) * b->phy_pin_count);
+    if (b->pins == NULL) {
+        free(b->adv_func);
+        free(b);
+        return NULL;
+    }
+
+    /* ADC */
+    b->aio_count = MRAA_ROCKPIE_V11_AIO_COUNT;
+    b->adc_raw = 10;
+    b->adc_supported = 10;
+    b->aio_dev[0].pin = 35;
+    b->aio_non_seq = 1;
+    b->pins[35].aio.pinmap = 1;
+
+    mraa_rockpie_v11_pininfo(b, 0,   -1, (mraa_pincapabilities_t){0,0,0,0,0,0,0,0}, "INVALID");
+    mraa_rockpie_v11_pininfo(b, 1,   -1, (mraa_pincapabilities_t){1,0,0,0,0,0,0,0}, "3V3");
+    mraa_rockpie_v11_pininfo(b, 2,   -1, (mraa_pincapabilities_t){1,0,0,0,0,0,0,0}, "5V");
+    mraa_rockpie_v11_pininfo(b, 3,   68, (mraa_pincapabilities_t){1,1,0,0,0,1,0,0}, "SDA1");
+    mraa_rockpie_v11_pininfo(b, 4,   -1, (mraa_pincapabilities_t){1,0,0,0,0,0,0,0}, "5V");
+    mraa_rockpie_v11_pininfo(b, 5,   69, (mraa_pincapabilities_t){1,1,0,0,0,1,0,0}, "SCL1");
+    mraa_rockpie_v11_pininfo(b, 6,   -1, (mraa_pincapabilities_t){1,0,0,0,0,0,0,0}, "GND");
+    mraa_rockpie_v11_pininfo(b, 7,  100, (mraa_pincapabilities_t){1,1,0,0,0,0,0,1}, "TXD1");
+    mraa_rockpie_v11_pininfo(b, 8,   64, (mraa_pincapabilities_t){1,1,0,0,0,0,0,1}, "TXD2");
+    mraa_rockpie_v11_pininfo(b, 9,   -1, (mraa_pincapabilities_t){1,0,0,0,0,0,0,0}, "GND");
+    mraa_rockpie_v11_pininfo(b, 10,  65, (mraa_pincapabilities_t){1,1,0,0,0,0,0,1}, "RXD2");
+    mraa_rockpie_v11_pininfo(b, 11,  96, (mraa_pincapabilities_t){1,1,0,0,1,0,0,0}, "SPI_CLK_M2");
+    mraa_rockpie_v11_pininfo(b, 12,  90, (mraa_pincapabilities_t){1,1,0,0,0,0,0,0}, "GPIO2_D2");
+    mraa_rockpie_v11_pininfo(b, 13, 104, (mraa_pincapabilities_t){1,1,0,0,1,0,0,0}, "SPI_CSN0_M2");
+    mraa_rockpie_v11_pininfo(b, 14,  -1, (mraa_pincapabilities_t){1,0,0,0,0,0,0,0}, "GND");
+    mraa_rockpie_v11_pininfo(b, 15,  98, (mraa_pincapabilities_t){1,1,0,0,1,0,0,0}, "SPI_RXD_M2");
+    mraa_rockpie_v11_pininfo(b, 16,  -1, (mraa_pincapabilities_t){1,0,0,0,0,0,0,0}, "USB20DM");
+    mraa_rockpie_v11_pininfo(b, 17,  -1, (mraa_pincapabilities_t){1,0,0,0,0,0,0,0}, "3V3");
+    mraa_rockpie_v11_pininfo(b, 18,  -1, (mraa_pincapabilities_t){1,0,0,0,0,0,0,0}, "USB20DP");
+    mraa_rockpie_v11_pininfo(b, 19,  27, (mraa_pincapabilities_t){1,1,0,0,0,0,0,0}, "GPIO0_D3");
+    mraa_rockpie_v11_pininfo(b, 20,  -1, (mraa_pincapabilities_t){1,0,0,0,0,0,0,0}, "GND");
+    mraa_rockpie_v11_pininfo(b, 21,  83, (mraa_pincapabilities_t){1,1,0,0,0,0,0,0}, "GPIO2_C3");
+    mraa_rockpie_v11_pininfo(b, 22,  76, (mraa_pincapabilities_t){1,1,0,0,0,0,0,0}, "GPIO2_B4");
+    mraa_rockpie_v11_pininfo(b, 23,  60, (mraa_pincapabilities_t){1,1,0,0,0,0,0,0}, "GPIO1_D4");
+    mraa_rockpie_v11_pininfo(b, 24,  67, (mraa_pincapabilities_t){1,1,0,0,0,0,0,0}, "GPIO2_A3");
+    mraa_rockpie_v11_pininfo(b, 25,  -1, (mraa_pincapabilities_t){1,0,0,0,0,0,0,0}, "GND");
+    mraa_rockpie_v11_pininfo(b, 26,  87, (mraa_pincapabilities_t){1,0,0,0,0,0,0,0}, "GPIO2_C7");
+    mraa_rockpie_v11_pininfo(b, 27,  97, (mraa_pincapabilities_t){1,1,0,0,1,0,0,0}, "SPI_TXD_M2");
+    mraa_rockpie_v11_pininfo(b, 28,  81, (mraa_pincapabilities_t){1,1,0,0,0,0,0,0}, "GPIO2_C1");
+    mraa_rockpie_v11_pininfo(b, 29,  80, (mraa_pincapabilities_t){1,1,0,0,0,0,0,0}, "GPIO2_C0");
+    mraa_rockpie_v11_pininfo(b, 30,  -1, (mraa_pincapabilities_t){1,0,0,0,0,0,0,0}, "GND");
+    mraa_rockpie_v11_pininfo(b, 31,  79, (mraa_pincapabilities_t){1,1,0,0,0,0,0,0}, "GPIO2_B7");
+    mraa_rockpie_v11_pininfo(b, 32, 102, (mraa_pincapabilities_t){1,1,0,0,0,0,0,1}, "UART1_RX");
+    mraa_rockpie_v11_pininfo(b, 33,  82, (mraa_pincapabilities_t){1,1,0,0,0,0,0,0}, "GPIO2_C2");
+    mraa_rockpie_v11_pininfo(b, 34,  -1, (mraa_pincapabilities_t){1,0,0,0,0,0,0,0}, "GND");
+    mraa_rockpie_v11_pininfo(b, 35,  -1, (mraa_pincapabilities_t){1,0,0,0,0,0,1,0}, "ADC_IN1");
+    mraa_rockpie_v11_pininfo(b, 36,  85, (mraa_pincapabilities_t){1,1,0,0,0,0,0,0}, "GPIO2_C5");
+    mraa_rockpie_v11_pininfo(b, 37,  66, (mraa_pincapabilities_t){1,1,0,0,0,0,0,0}, "GPIO2_A2");
+    mraa_rockpie_v11_pininfo(b, 38,  84, (mraa_pincapabilities_t){1,1,0,0,0,0,0,0}, "GPIO2_C4");
+    mraa_rockpie_v11_pininfo(b, 39,  -1, (mraa_pincapabilities_t){1,0,0,0,0,0,0,0}, "GND");
+    mraa_rockpie_v11_pininfo(b, 40,  86, (mraa_pincapabilities_t){1,1,0,0,0,0,0,0}, "GPIO2_C6");
+
+    return b;
+}

--- a/src/x86/rockpix.c
+++ b/src/x86/rockpix.c
@@ -1,0 +1,208 @@
+/*
+ * Author: Shine <yll@radxa.com>
+ * Copyright (c) 2019 Vamrs Corporation.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include <stdlib.h>
+#include <string.h>
+#include <ctype.h>
+
+#include "common.h"
+#include "x86/rockpix.h"
+
+#define PLATFORM_NAME "ROCK PI X"
+#define PLATFORM_VERSION "1.0.0"
+
+#define MRAA_ROCK_PI_X_VIRTUAL   220  /* 0~7 */
+#define MRAA_ROCK_PI_X_SOUTHEAST 228  /* 0~85 */
+#define MRAA_ROCK_PI_X_EAST      314  /* 0~26 */
+#define MRAA_ROCK_PI_X_NORTH     341  /* 0~72 */
+#define MRAA_ROCK_PI_X_SOUTHWEST 414  /* 0~97 */
+
+static mraa_result_t
+mraa_rockpix_set_pininfo(mraa_board_t* board, int mraa_index, char* name, mraa_pincapabilities_t caps, int sysfs_pin)
+{
+    if (mraa_index < board->phy_pin_count) {
+        mraa_pininfo_t* pin_info = &board->pins[mraa_index];
+        strncpy(pin_info->name, name, MRAA_PIN_NAME_SIZE);
+        pin_info->capabilities = caps;
+        if (caps.gpio) {
+            pin_info->gpio.pinmap = sysfs_pin;
+            pin_info->gpio.mux_total = 0;
+        }
+        if (caps.i2c) {
+            pin_info->i2c.pinmap = 1;
+            pin_info->i2c.mux_total = 0;
+        }
+        if (caps.pwm) {
+            pin_info->pwm.parent_id = 0;
+            pin_info->pwm.pinmap = 0;
+            pin_info->pwm.mux_total = 0;
+        }
+        if (caps.spi) {
+            pin_info->spi.mux_total = 0;
+        }
+        if (caps.uart) {
+            pin_info->uart.mux_total = 0;
+        }
+        return MRAA_SUCCESS;
+    }
+    return MRAA_ERROR_INVALID_RESOURCE;
+}
+
+static mraa_result_t
+mraa_rockpix_get_pin_index(mraa_board_t* board, char* name, int* pin_index)
+{
+    int i;
+    for (i = 0; i < board->phy_pin_count; ++i) {
+        if (strncmp(name, board->pins[i].name, MRAA_PIN_NAME_SIZE) == 0) {
+            *pin_index = i;
+            return MRAA_SUCCESS;
+        }
+    }
+
+    syslog(LOG_CRIT, "ROCK PI X: Failed to find pin name %s", name);
+
+    return MRAA_ERROR_INVALID_RESOURCE;
+}
+
+mraa_board_t*
+mraa_rockpix_board()
+{
+    mraa_board_t* b = (mraa_board_t*) calloc(1, sizeof(mraa_board_t));
+
+    if (b == NULL) {
+        return NULL;
+    }
+
+    b->platform_name = PLATFORM_NAME;
+    b->platform_version = PLATFORM_VERSION;
+    b->phy_pin_count = MRAA_ROCKPIX_PINCOUNT;
+    b->gpio_count = MRAA_ROCKPIX_GPIOCOUNT;
+
+    b->pins = (mraa_pininfo_t*) malloc(sizeof(mraa_pininfo_t) * MRAA_ROCKPIX_PINCOUNT);
+    if (b->pins == NULL) {
+        goto error;
+    }
+
+    b->adv_func = (mraa_adv_func_t*) calloc(1, sizeof(mraa_adv_func_t));
+    if (b->adv_func == NULL) {
+        free(b->pins);
+        goto error;
+    }
+
+    mraa_rockpix_set_pininfo(b, 0,  "INVALID",     (mraa_pincapabilities_t){ 0, 0, 0, 0, 0, 0, 0, 0 }, -1);
+    mraa_rockpix_set_pininfo(b, 1,  "3.3v",        (mraa_pincapabilities_t){ 1, 0, 0, 0, 0, 0, 0, 0 }, -1);
+    mraa_rockpix_set_pininfo(b, 2,  "5v",          (mraa_pincapabilities_t){ 1, 0, 0, 0, 0, 0, 0, 0 }, -1);
+    mraa_rockpix_set_pininfo(b, 3,  "I2C2_SDA",    (mraa_pincapabilities_t){ 1, 0, 0, 0, 0, 1, 0, 0 }, -1);
+    mraa_rockpix_set_pininfo(b, 4,  "5v",          (mraa_pincapabilities_t){ 0, 0, 0, 0, 0, 0, 0, 0 }, -1);
+    mraa_rockpix_set_pininfo(b, 5,  "I2C2_SCL",    (mraa_pincapabilities_t){ 1, 0, 0, 0, 0, 1, 0, 0 }, -1);
+    mraa_rockpix_set_pininfo(b, 6,  "GND",         (mraa_pincapabilities_t){ 1, 0, 0, 0, 0, 0, 0, 0 }, -1);
+    mraa_rockpix_set_pininfo(b, 7,  "ISH_GPIO0",   (mraa_pincapabilities_t){ 1, 1, 0, 0, 0, 1, 0, 0 }, 335);
+    mraa_rockpix_set_pininfo(b, 8,  "UART2_TX",    (mraa_pincapabilities_t){ 1, 0, 0, 0, 0, 0, 0, 1 }, -1);
+    mraa_rockpix_set_pininfo(b, 9,  "GND",         (mraa_pincapabilities_t){ 1, 0, 0, 0, 0, 0, 0, 0 }, -1);
+    mraa_rockpix_set_pininfo(b, 10, "UART2_RX",    (mraa_pincapabilities_t){ 1, 0, 0, 0, 0, 0, 0, 1 }, -1);
+    mraa_rockpix_set_pininfo(b, 11, "SPI2_CLK",    (mraa_pincapabilities_t){ 1, 0, 0, 0, 1, 0, 0, 1 }, -1);
+    mraa_rockpix_set_pininfo(b, 12, "GPIO_DFX3",   (mraa_pincapabilities_t){ 1, 1, 0, 0, 0, 0, 0, 0 }, 345);
+    mraa_rockpix_set_pininfo(b, 13, "SPI2_MISO",   (mraa_pincapabilities_t){ 1, 0, 0, 0, 1, 0, 0, 1 }, -1);
+    mraa_rockpix_set_pininfo(b, 14, "GND",         (mraa_pincapabilities_t){ 1, 0, 0, 0, 0, 0, 0, 0 }, -1);
+    mraa_rockpix_set_pininfo(b, 15, "SPI2_CS0",    (mraa_pincapabilities_t){ 1, 0, 0, 0, 1, 0, 0, 0 }, -1);
+    mraa_rockpix_set_pininfo(b, 16, "SPI2_MOSI",   (mraa_pincapabilities_t){ 1, 1, 0, 0, 1, 0, 0, 0 }, 346);
+    mraa_rockpix_set_pininfo(b, 17, "+3.3V",       (mraa_pincapabilities_t){ 1, 0, 0, 0, 0, 0, 0, 0 }, -1);
+    mraa_rockpix_set_pininfo(b, 18, "UART2_RTS",   (mraa_pincapabilities_t){ 1, 0, 0, 0, 0, 0, 0, 1 }, -1);
+    mraa_rockpix_set_pininfo(b, 19, "SPI_MOSI",    (mraa_pincapabilities_t){ 1, 0, 0, 0, 1, 1, 0, 0 }, -1);
+    mraa_rockpix_set_pininfo(b, 20, "GND",         (mraa_pincapabilities_t){ 1, 0, 0, 0, 0, 0, 0, 0 }, -1);
+    mraa_rockpix_set_pininfo(b, 21, "SPI_MISO",    (mraa_pincapabilities_t){ 1, 1, 0, 0, 1, 0, 0, 0 }, 334);
+    mraa_rockpix_set_pininfo(b, 22, "UART2_CTS",   (mraa_pincapabilities_t){ 1, 0, 0, 0, 0, 0, 0, 1 }, -1);
+    mraa_rockpix_set_pininfo(b, 23, "SPI_CLK",     (mraa_pincapabilities_t){ 1, 0, 0, 0, 1, 1, 0, 0 }, -1);
+    mraa_rockpix_set_pininfo(b, 24, "ISH_GPIO1",   (mraa_pincapabilities_t){ 1, 1, 0, 0, 0, 0, 0, 0 }, 332);
+    mraa_rockpix_set_pininfo(b, 25, "GND",         (mraa_pincapabilities_t){ 1, 0, 0, 0, 0, 0, 0, 0 }, -1);
+    mraa_rockpix_set_pininfo(b, 26, "ISH_GPIO4",   (mraa_pincapabilities_t){ 1, 1, 0, 0, 0, 0, 0, 0 }, 336);
+    mraa_rockpix_set_pininfo(b, 27, "I2C5_DATA",   (mraa_pincapabilities_t){ 1, 0, 0, 0, 0, 1, 0, 0 }, -1);
+    mraa_rockpix_set_pininfo(b, 28, "I2C5_CLK",    (mraa_pincapabilities_t){ 1, 0, 0, 0, 0, 1, 0, 0 }, -1);
+    mraa_rockpix_set_pininfo(b, 29, "ISH_GPIO2",   (mraa_pincapabilities_t){ 1, 1, 0, 0, 0, 0, 0, 0 }, 338);
+    mraa_rockpix_set_pininfo(b, 30, "GND",         (mraa_pincapabilities_t){ 0, 0, 0, 0, 0, 0, 0, 0 }, -1);
+    mraa_rockpix_set_pininfo(b, 31, "ISH_GPIO3",   (mraa_pincapabilities_t){ 1, 1, 0, 0, 0, 0, 0, 0 }, 329);
+    mraa_rockpix_set_pininfo(b, 32, "PWM0",        (mraa_pincapabilities_t){ 1, 0, 1, 0, 0, 0, 0, 0 }, -1);
+    mraa_rockpix_set_pininfo(b, 33, "PWM1",        (mraa_pincapabilities_t){ 1, 1, 1, 0, 0, 0, 0, 1 }, 229);
+    mraa_rockpix_set_pininfo(b, 34, "GND",         (mraa_pincapabilities_t){ 1, 0, 0, 0, 0, 0, 0, 0 }, -1);
+    mraa_rockpix_set_pininfo(b, 35, "I2S1_FRM",    (mraa_pincapabilities_t){ 1, 0, 0, 0, 0, 0, 0, 0 }, -1);
+    mraa_rockpix_set_pininfo(b, 36, "I2S1_CLK",    (mraa_pincapabilities_t){ 1, 0, 0, 0, 0, 0, 0, 0 }, -1);
+    mraa_rockpix_set_pininfo(b, 37, "ISH_GPIO13",  (mraa_pincapabilities_t){ 1, 1, 0, 0, 0, 0, 0, 0 }, 348);
+    mraa_rockpix_set_pininfo(b, 38, "I2S1_RX",     (mraa_pincapabilities_t){ 1, 0, 0, 0, 0, 0, 0, 0 }, -1);
+    mraa_rockpix_set_pininfo(b, 39, "GND",         (mraa_pincapabilities_t){ 1, 0, 0, 0, 0, 0, 0, 0 }, -1);
+    mraa_rockpix_set_pininfo(b, 40, "I2S1_TX",     (mraa_pincapabilities_t){ 1, 0, 0, 0, 0, 0, 0, 0 }, -1);
+
+    // Set number of i2c adaptors usable from userspace
+    b->i2c_bus_count = 0;
+    b->def_i2c_bus = 0;
+    int i2c_bus_num;
+
+    // Configure i2c adaptor #0 (default)
+    i2c_bus_num = mraa_find_i2c_bus_pci("0000:00", "808622C1:02", ".");
+    if (i2c_bus_num != -1) {
+        int i = b->i2c_bus_count;
+        b->i2c_bus[i].bus_id = i2c_bus_num;
+        mraa_rockpix_get_pin_index(b, "I2C2_SDA", (int*) &(b->i2c_bus[0].sda));
+        mraa_rockpix_get_pin_index(b, "I2C2_SCL", (int*) &(b->i2c_bus[0].scl));
+        b->i2c_bus_count++;
+    }
+
+    // Configure i2c adaptor #1
+    i2c_bus_num = mraa_find_i2c_bus_pci("0000:00", "808622C1:05", ".");
+    if (i2c_bus_num != -1) {
+        int i = b->i2c_bus_count;
+        b->i2c_bus[i].bus_id = i2c_bus_num;
+        mraa_rockpix_get_pin_index(b, "I2C5_DATA", (int*) &(b->i2c_bus[1].sda));
+        mraa_rockpix_get_pin_index(b, "I2C5_CLK", (int*) &(b->i2c_bus[1].scl));
+        b->i2c_bus_count++;
+    }
+
+    // Configure PWM
+    b->pwm_dev_count = 0;
+    b->def_pwm_dev = 0;
+    b->pwm_default_period = 5000;
+    b->pwm_max_period = 218453;
+    b->pwm_min_period = 1;
+
+    // set the correct pwm channels for pwm 1 2
+    b->pins[32].pwm.parent_id = 0;
+    b->pins[32].pwm.pinmap = 0;
+    b->pwm_dev_count++;
+
+    // Configure SPI #0 CS0 (default)
+    b->spi_bus_count = MRAA_ROCKPIX_SPI_COUNT;
+    b->spi_bus[0].bus_id = 2;
+    b->spi_bus[0].slave_s = 0;
+    mraa_rockpix_get_pin_index(b, "SPI2_CS0", (int*) &(b->spi_bus[0].cs));
+    mraa_rockpix_get_pin_index(b, "SPI2_MOSI", (int*) &(b->spi_bus[0].mosi));
+    mraa_rockpix_get_pin_index(b, "SPI2_MISO", (int*) &(b->spi_bus[0].miso));
+    mraa_rockpix_get_pin_index(b, "SPI2_CLK", (int*) &(b->spi_bus[0].sclk));
+    b->def_spi_bus = 0;
+
+    // Configure UART #1 (default)
+    b->uart_dev_count = MRAA_ROCKPIX_UART_COUNT;
+    mraa_rockpix_get_pin_index(b, "UART2_RX",  &(b->uart_dev[0].rx));
+    mraa_rockpix_get_pin_index(b, "UART2_TX",  &(b->uart_dev[0].tx));
+    mraa_rockpix_get_pin_index(b, "UART2_CTS", &(b->uart_dev[0].cts));
+    mraa_rockpix_get_pin_index(b, "UART2_RTS", &(b->uart_dev[0].rts));
+    b->uart_dev[0].device_path = "/dev/ttyS5";
+    b->def_uart_dev = 0;
+
+    // Configure ADCs
+    b->aio_count = MRAA_ROCKPIX_ADC_COUNT;
+
+    const char* pinctrl_path = "/sys/bus/platform/drivers/cherryview-pinctrl";
+    int have_pinctrl = access(pinctrl_path, F_OK) != -1;
+    syslog(LOG_NOTICE, "ROCK PI X: kernel pinctrl driver %savailable", have_pinctrl ? "" : "un");
+
+    if (have_pinctrl)
+        return b;
+
+error:
+    syslog(LOG_CRIT, "ROCK PI X: Platform failed to initialise");
+    free(b);
+    return NULL;
+}

--- a/src/x86/x86.c
+++ b/src/x86/x86.c
@@ -25,6 +25,7 @@
 #include "x86/iei_tank.h"
 #include "x86/intel_adlink_lec_al.h"
 #include "x86/up_xtreme.h"
+#include "x86/rockpix.h"
 
 mraa_platform_t
 mraa_x86_platform()
@@ -84,6 +85,9 @@ mraa_x86_platform()
             } else if (strncasecmp(line, "UP-APL01", strlen("UP-APL01") + 1) == 0) {
                 platform_type = MRAA_UP2;
                 plat = mraa_up2_board();
+            } else if (strncasecmp(line, "ROCK Pi X", strlen("ROCK Pi X") + 1) == 0) {
+                platform_type = MRAA_ROCKPIX;
+                plat = mraa_rockpix_board();
             } else if (strncasecmp(line, "RVP", strlen("RVP") + 1) == 0) {
                 platform_type = MRAA_INTEL_JOULE_EXPANSION;
                 plat = mraa_joule_expansion_board();
@@ -162,6 +166,8 @@ mraa_x86_platform()
     plat = mraa_up_board();
     #elif defined(xMRAA_UP2)
     plat = mraa_up2_board();
+    #elif defined(xMRAA_ROCKPIX)
+    plat = mraa_rockpix_board();
     #elif defined(xMRAA_INTEL_JOULE_EXPANSION)
     plat = mraa_joule_expansion_board();
     #elif defined(xMRAA_IEI_TANK)


### PR DESCRIPTION
Added support for ROCK Pi 4C, ROCK Pi E, ROCK Pi X. Added examples/java/CMakeLists.txt file to support the compilation of java routines. 
Fix the bug of rockpi4 board name error.

Signed-off-by: Shine <shine@vamrs.com>